### PR TITLE
Add miniscule amount of padding for vertically aligned arms do not actually touch

### DIFF
--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -47,7 +47,7 @@ let tetrahedrons = []
 let magnetizationFields = [];
 
 const renderMesh = async () => {
-	const padding = { x: 0, y: 0 };
+	const padding = { x: 0, y: 0.00001 };
 	const componentModel = await (await fetch('res/triangle.json')).json()
 	const result = arrangeModel(positionGrid.toReversed(), magnetizationGrid.toReversed(), componentModel, padding)
 	tetrahedrons = result.tetrahedrons


### PR DESCRIPTION
Add really small amount of padding because arms are touching each other in the coordinate system even though it doesn't look like it in the rendering.

Before
![image](https://github.com/user-attachments/assets/7e555714-ed15-49f4-b892-5072a04015be)

After
![image](https://github.com/user-attachments/assets/363a816b-97d0-41e2-b72e-7acd18f0630e)
